### PR TITLE
Updated TSDB Relay to allow connecting to Bosun / OpenTSDB hosted behind SSL Load balancer 

### DIFF
--- a/cmd/tsdbrelay/main.go
+++ b/cmd/tsdbrelay/main.go
@@ -36,6 +36,7 @@ var (
 	logVerbose      = flag.Bool("v", false, "enable verbose logging")
 	toDenormalize   = flag.String("denormalize", "", "List of metrics to denormalize. Comma seperated list of `metric__tagname__tagname` rules. Will be translated to `__tagvalue.tagvalue.metric`")
 	flagVersion     = flag.Bool("version", false, "Prints the version and exits.")
+	protocol	= flag.String("p", "http", "http or https protocol for communication to Bosun and OpenTSDB")
 
 	redisHost = flag.String("redis", "", "redis host for aggregating external counters")
 	redisDb   = flag.Int("db", 0, "redis db to use for counters")
@@ -105,22 +106,22 @@ func main() {
 	}
 
 	tsdbURL := &url.URL{
-		Scheme: "http",
+		Scheme: *protocol,
 		Host:   *tsdbServer,
 	}
 
 	u := url.URL{
-		Scheme: "http",
+		Scheme: *protocol,
 		Host:   *tsdbServer,
 		Path:   "/api/put",
 	}
 	tsdbPutURL = u.String()
 	bosunURL := &url.URL{
-		Scheme: "http",
+		Scheme: *protocol,
 		Host:   *bosunServer,
 	}
 	u = url.URL{
-		Scheme: "http",
+		Scheme: *protocol,
 		Host:   *bosunServer,
 		Path:   "/api/index",
 	}
@@ -128,7 +129,7 @@ func main() {
 	if *secondaryRelays != "" {
 		for _, rUrl := range strings.Split(*secondaryRelays, ",") {
 			u = url.URL{
-				Scheme: "http",
+				Scheme: *protocol,
 				Host:   rUrl,
 				Path:   "/api/put",
 			}


### PR DESCRIPTION
Added the ability for tsdbrelay to connect to a Bosun / OpenTSDB cluster hosted behind a SSL terminating load balancer.

This allows for data to be sent across a more secure channel.